### PR TITLE
plugin/: add double load guard

### DIFF
--- a/plugin/ripple.vim
+++ b/plugin/ripple.vim
@@ -20,6 +20,11 @@
 " OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 " THE SOFTWARE.
 
+if exists('g:loaded_ripple') || &cp
+    finish
+endif
+let g:loaded_ripple = 1
+
 let s:default_enable_mappings = 1
 
 nnoremap <silent> <Plug>(ripple_open_repl) :call ripple#open_repl()<cr>


### PR DESCRIPTION
Adds checks to prevent double loading, and a new variable (`g:loaded_ripple`) to look if the plugin is loaded or not, for conditionally evaluated configurations.